### PR TITLE
Some fixes in german translation

### DIFF
--- a/constants/translations.ts
+++ b/constants/translations.ts
@@ -93,7 +93,7 @@ export const translations = {
   },
   changeStation: {
     en: "Change station",
-    de: "Station ädndern",
+    de: "Station ändern",
     no: "Endre stasjon",
     sv: "Byt station",
   },

--- a/constants/translations.ts
+++ b/constants/translations.ts
@@ -171,7 +171,7 @@ export const translations = {
   },
   ago: {
     en: "ago",
-    de: "seit",
+    de: "her",
     no: "siden",
     sv: "sedan",
   },


### PR DESCRIPTION
- found a typo in the german translation
- context based change of translation for "ago"